### PR TITLE
#138 Rerouted doil base help

### DIFF
--- a/src/doil.sh
+++ b/src/doil.sh
@@ -16,7 +16,7 @@
 # check the most basic thing
 if [ -z ${1:+x} ]
 then
-  eval "/usr/local/lib/doil/lib/system/help.sh"
+  eval "/usr/local/lib/doil/lib/help.sh"
   exit
 fi
 


### PR DESCRIPTION
See #138

If `doil` is entered without anything it'll show the base help now.