### PR TITLE
#140 Implemented missing xmlrpc for php 7.4

### DIFF
--- a/src/stack/states/php7.4/php/init.sls
+++ b/src/stack/states/php7.4/php/init.sls
@@ -15,6 +15,7 @@ php7.4:
       - php7.4-soap
       - php7.4-bcmath
       - php7.4-imap
+      - php7.4-xmlrpc
 
 php7.0:
   pkg.removed:


### PR DESCRIPTION
See #140 