### PR TITLE
frh wizard/parameters:302 get rid of -n parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ After you installed doil the basic system is ready to go. To get an instance of
 ILIAS running you simply need to do following steps:
 
 1. Head to a folder where you want to store your project. Usually `~/Projects`
-1. Enter following command: `doil create -n -e ilias7 -r ilias -b release_7 -p 7.4 -u`
+1. Enter following command: `doil create -e ilias7 -r ilias -b release_7 -p 7.4 -u`
 
 Don't worry, this will take a while. It creates and instance of ILIAS named `ilias7`
 in your location from the repository `ilias` (see `doil repo:list`) with the known
@@ -255,7 +255,7 @@ via Dockers volumes and can be accessed from the host system.
 
 ### System
 
-**doil** comes with some helpers which are usefull if you want to hack on **doil**:
+**doil** comes with some helpers which are useful if you want to hack on **doil**:
 
 * `doil system:uninstall` will remove doil from your system. users, instance and config remain 
 * `doil system:uninstall --prune` will remove doil completely from your system for all users
@@ -330,7 +330,7 @@ users, so make sure to understand what you are doing.
 Option 1: An instance can be created with the '-x' flag, or alternatively 
 in interactive mode you will be asked to install xdebug.  
 On the command line it could look like this:  
-* `doil create -n -e ilias7 -r ilias -b release_7 -p 7.4 -u -x`
+* `doil create -e ilias7 -r ilias -b release_7 -p 7.4 -u -x`
 
 Option 2: You can apply a state to an already existing instance.  
 To activate xdebug use the following command:

--- a/app/tests/Commands/Instances/CreateCommandTest.php
+++ b/app/tests/Commands/Instances/CreateCommandTest.php
@@ -45,36 +45,6 @@ class CreateCommandWrapper extends CreateCommand
 
 class CreateCommandTest extends TestCase
 {
-    public function test_execute_with_empty_instance_param() : void
-    {
-        $docker = $this->createMock(Docker::class);
-        $repo_manager = $this->createMock(RepoManager::class);
-        $git = $this->createMock(Git::class);
-        $posix = $this->createMock(Posix::class);
-        $filesystem = $this->createMock(Filesystem::class);
-        $linux = $this->createMock(Linux::class);
-        $project_config = $this->createMock(ProjectConfig::class);
-        $writer = new CommandWriter();
-
-        $command = new CreateCommand(
-            $docker,
-            $repo_manager,
-            $git,
-            $posix,
-            $filesystem,
-            $linux,
-            $project_config,
-            $writer
-        );
-        $tester = new CommandTester($command);
-        $app = new Application("doil");
-        $command->setApplication($app);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Name of the instance cannot be empty!");
-        $tester->execute(["--no-interaction" => true]);
-    }
-
     public function test_execute_with_wrong_chars_in_instance_param() : void
     {
         $docker = $this->createMock(Docker::class);
@@ -130,69 +100,9 @@ class CreateCommandTest extends TestCase
         $app = new Application("doil");
         $command->setApplication($app);
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Repo can not be null!");
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Choice question must have at least 1 choice available.");
         $tester->execute(["--no-interaction" => true, "--name" => "1232"]);
-    }
-
-    public function test_execute_with_no_branch_param() : void
-    {
-        $docker = $this->createMock(Docker::class);
-        $repo_manager = $this->createMock(RepoManager::class);
-        $git = $this->createMock(Git::class);
-        $posix = $this->createMock(Posix::class);
-        $filesystem = $this->createMock(Filesystem::class);
-        $linux = $this->createMock(Linux::class);
-        $project_config = $this->createMock(ProjectConfig::class);
-        $writer = new CommandWriter();
-
-        $command = new CreateCommand(
-            $docker,
-            $repo_manager,
-            $git,
-            $posix,
-            $filesystem,
-            $linux,
-            $project_config,
-            $writer
-        );
-        $tester = new CommandTester($command);
-        $app = new Application("doil");
-        $command->setApplication($app);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Branch can not be null!");
-        $tester->execute(["--no-interaction" => true, "--name" => "1232", "--repo" => "foo"]);
-    }
-
-    public function test_execute_with_no_phpversion_param() : void
-    {
-        $docker = $this->createMock(Docker::class);
-        $repo_manager = $this->createMock(RepoManager::class);
-        $git = $this->createMock(Git::class);
-        $posix = $this->createMock(Posix::class);
-        $filesystem = $this->createMock(Filesystem::class);
-        $linux = $this->createMock(Linux::class);
-        $project_config = $this->createMock(ProjectConfig::class);
-        $writer = new CommandWriter();
-
-        $command = new CreateCommand(
-            $docker,
-            $repo_manager,
-            $git,
-            $posix,
-            $filesystem,
-            $linux,
-            $project_config,
-            $writer
-        );
-        $tester = new CommandTester($command);
-        $app = new Application("doil");
-        $command->setApplication($app);
-
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("PHP version can not be null!");
-        $tester->execute(["--no-interaction" => true, "--name" => "1232", "--repo" => "foo", "--branch" => "foo"]);
     }
 
     public function test_execute_with_wrong_formatted_phpversion_param() : void
@@ -258,11 +168,6 @@ class CreateCommandTest extends TestCase
 
         $filesystem
             ->expects($this->once())
-            ->method("getCurrentWorkingDirectory")
-            ->willReturn("/home/test")
-        ;
-        $filesystem
-            ->expects($this->once())
             ->method("exists")
             ->with("/home/test")
             ->willReturn(false)
@@ -271,11 +176,11 @@ class CreateCommandTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("the path '/home/test' does not exists!");
         $tester->execute([
-            "--no-interaction" => true,
             "--name" => "1232",
             "--repo" => "foo",
             "--branch" => "foo",
-            "--phpversion" => "2.3"
+            "--phpversion" => "2.3",
+            "--target" => "/home/test"
         ]);
     }
 
@@ -306,11 +211,6 @@ class CreateCommandTest extends TestCase
 
         $filesystem
             ->expects($this->once())
-            ->method("getCurrentWorkingDirectory")
-            ->willReturn("/home/test")
-        ;
-        $filesystem
-            ->expects($this->once())
             ->method("exists")
             ->with("/home/test")
             ->willReturn(true)
@@ -329,7 +229,8 @@ class CreateCommandTest extends TestCase
             "--name" => "1232",
             "--repo" => "foo",
             "--branch" => "foo",
-            "--phpversion" => "2.3"
+            "--phpversion" => "2.3",
+            "--target" => "/home/test"
         ]);
     }
 
@@ -425,11 +326,11 @@ class CreateCommandTest extends TestCase
         ;
 
         $tester->execute([
-            "--no-interaction" => true,
             "--name" => "1232",
             "--repo" => "foo",
             "--branch" => "foo",
-            "--phpversion" => "2.3"
+            "--phpversion" => "2.3",
+            "--target" => "/home/test"
         ]);
     }
 }


### PR DESCRIPTION
Remove the condition of an existing -n parameter to use command line args.
Also, it is now possible to add only a few cmdline args and the other args will be completed by the wizzard.
To use the create and repo:add command in scripts you have to fulfill all args. If you want, you can add flags too. But non existing flags will not stop a script. 

https://github.com/conceptsandtraining/doil/issues/302