### PR TITLE
frh repo:294 cant add a repo with same url anymore for local or global, also import checks for an existing repo url and use this url instead to add a ne repo

### DIFF
--- a/app/src/Commands/Instances/CreateCommand.php
+++ b/app/src/Commands/Instances/CreateCommand.php
@@ -449,13 +449,13 @@ class CreateCommand extends Command
 
             if ($use_global_repo) {
                 $options["repo_path"] = self::GLOBAL_REPO_PATH . "/" . $repo;
-                $r = $this->repo_manager->getGlobalRepo($repo);
+                $r = $this->repo_manager->getGlobalRepoByName($repo);
             }
 
             if (!$use_global_repo) {
                 $home_dir = $this->posix->getHomeDirectory($this->posix->getUserId());
                 $options["repo_path"] = $home_dir . self::LOCAL_REPO_PATH . "/" . $repo;
-                $r = $this->repo_manager->getLocalRepo($repo);
+                $r = $this->repo_manager->getLocalRepoByName($repo);
             }
 
             $options["repo"] = $r->getName();
@@ -623,7 +623,7 @@ class CreateCommand extends Command
         $this->git->setLocalConfig(
             $path,
             "remote.origin.fetch",
-            "refs/heads/*:refs/heads/*"
+            "+refs/heads/*:refs/heads/*"
         );
         $this->git->fetchBare($path);
         $branches = $this->git->getBranches($path);

--- a/app/src/Commands/Repo/AddCommand.php
+++ b/app/src/Commands/Repo/AddCommand.php
@@ -43,8 +43,6 @@ class AddCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output) : int
     {
-
-
         $repo = $this->gatherRepoData($input, $output);
 
         $check = $this->checkName();
@@ -52,10 +50,20 @@ class AddCommand extends Command
         $check = $this->checkUrl();
         $check($repo->getUrl());
 
-        if ($this->repo_manager->repoExists($repo)) {
+        if ($this->repo_manager->repoUrlExists($repo)) {
             $this->writer->error(
                 $output,
-                "Repository {$repo->getName()} already exists!",
+                "Repository with url '{$repo->getUrl()}' already exists!",
+                "Use <fg=gray>doil repo:list</> to see current installed repos."
+            );
+
+            return Command::FAILURE;
+        }
+
+        if ($this->repo_manager->repoNameExists($repo)) {
+            $this->writer->error(
+                $output,
+                "Repository with name '{$repo->getName()}' already exists!",
                 "Use <fg=gray>doil repo:list</> to see current installed repos."
             );
 

--- a/app/src/Commands/Repo/DeleteCommand.php
+++ b/app/src/Commands/Repo/DeleteCommand.php
@@ -94,7 +94,7 @@ class DeleteCommand extends Command
             ->withIsGlobal($global)
         ;
 
-        if (! $this->repo_manager->repoExists($repo)) {
+        if (! $this->repo_manager->repoNameExists($repo)) {
             $this->writer->error(
                 $output,
                 "Repository $name does not exists!",

--- a/app/src/Commands/Repo/RepoManager.php
+++ b/app/src/Commands/Repo/RepoManager.php
@@ -32,7 +32,7 @@ class RepoManager
         return new Repo();
     }
 
-    public function repoExists(Repo $repo) : bool
+    public function repoNameExists(Repo $repo) : bool
     {
         $repos = $this->getLocalRepos();
         if ($repo->isGlobal()) {
@@ -41,6 +41,23 @@ class RepoManager
 
         $repos = array_filter($repos, function(Repo $r) use ($repo) {
             if ($repo->getName() == $r->getName()) {
+                return true;
+            }
+            return false;
+        });
+
+        return (bool) count($repos);
+    }
+
+    public function repoUrlExists(Repo $repo) : bool
+    {
+        $repos = $this->getLocalRepos();
+        if ($repo->isGlobal()) {
+            $repos = $this->getGlobalRepos();
+        }
+
+        $repos = array_filter($repos, function(Repo $r) use ($repo) {
+            if ($repo->getUrl() == $r->getUrl()) {
                 return true;
             }
             return false;
@@ -145,7 +162,7 @@ class RepoManager
         return $this->filesystem->readFromJsonFile(self::GLOBAL_REPO_CONFIG_PATH);
     }
 
-    public function getLocalRepo(string $name) : Repo
+    public function getLocalRepoByName(string $name) : Repo
     {
         $repos = $this->getLocalRepos();
         $repos = array_filter($repos, function(Repo $r) use ($name) {
@@ -156,13 +173,30 @@ class RepoManager
         });
 
         if (! count($repos)) {
-            throw new RuntimeException("Repo $name not found in local repos.");
+            throw new RuntimeException("Repo with name '$name' not found in local repos.");
         }
 
         return array_shift($repos);
     }
 
-    public function getGlobalRepo(string $name) : Repo
+    public function getLocalRepoByUrl(string $url) : Repo
+    {
+        $repos = $this->getLocalRepos();
+        $repos = array_filter($repos, function(Repo $r) use ($url) {
+            if ($url == $r->getUrl()) {
+                return true;
+            }
+            return false;
+        });
+
+        if (! count($repos)) {
+            throw new RuntimeException("Repo with url '$url' not found in local repos.");
+        }
+
+        return array_shift($repos);
+    }
+
+    public function getGlobalRepoByName(string $name) : Repo
     {
         $repos = $this->getGlobalRepos();
         $repos = array_filter($repos, function(Repo $r) use ($name) {
@@ -173,7 +207,24 @@ class RepoManager
         });
 
         if (! count($repos)) {
-            throw new RuntimeException("Repo $name not found in global repos.");
+            throw new RuntimeException("Repo with name '$name' not found in global repos.");
+        }
+
+        return array_shift($repos);
+    }
+
+    public function getGlobalRepoByUrl(string $url) : Repo
+    {
+        $repos = $this->getGlobalRepos();
+        $repos = array_filter($repos, function(Repo $r) use ($url) {
+            if ($url == $r->getUrl()) {
+                return true;
+            }
+            return false;
+        });
+
+        if (! count($repos)) {
+            throw new RuntimeException("Repo with url '$url' not found in global repos.");
         }
 
         return array_shift($repos);

--- a/app/src/Commands/Repo/UpdateCommand.php
+++ b/app/src/Commands/Repo/UpdateCommand.php
@@ -95,7 +95,7 @@ class UpdateCommand extends Command
             ->withIsGlobal($global)
         ;
 
-        if (! $this->repo_manager->repoExists($repo)) {
+        if (! $this->repo_manager->repoNameExists($repo)) {
             $this->writer->error(
                 $output,
                 "Repository $name does not exists!",

--- a/app/tests/Commands/Repo/AddCommandTest.php
+++ b/app/tests/Commands/Repo/AddCommandTest.php
@@ -112,7 +112,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals(1, $execute_result);
     }
 
-    public function test_execute_with_already_existing_repo() : void
+    public function test_execute_with_already_existing_repo_url() : void
     {
         $repo_manager = $this->createMock(RepoManager::class);
         $writer = new CommandWriter();
@@ -130,7 +130,7 @@ class AddCommandTest extends TestCase
         $repo = new Repo("doil", "https://test/doil.git", false);
         $repo_manager
             ->expects($this->once())
-            ->method("repoExists")
+            ->method("repoUrlExists")
             ->with($repo)
             ->willReturn(true)
         ;
@@ -138,7 +138,38 @@ class AddCommandTest extends TestCase
         $execute_result = $tester->execute(["--no-interaction" => true, "--name" => "doil", "--url" => "https://test/doil.git"]);
         $output = $tester->getDisplay(true);
 
-        $result = "Error:\n\tRepository doil already exists!\n\tUse doil repo:list to see current installed repos.\n";
+        $result = "Error:\n\tRepository with url 'https://test/doil.git' already exists!\n\tUse doil repo:list to see current installed repos.\n";
+        $this->assertEquals($result, $output);
+        $this->assertEquals(1, $execute_result);
+    }
+
+    public function test_execute_with_already_existing_repo_name() : void
+    {
+        $repo_manager = $this->createMock(RepoManager::class);
+        $writer = new CommandWriter();
+
+        $command = new AddCommand($repo_manager, $writer);
+        $tester = new CommandTester($command);
+        $app = new Application("doil");
+        $command->setApplication($app);
+
+        $repo_manager
+            ->expects($this->once())
+            ->method("getEmptyRepo")
+            ->willReturn(new Repo())
+        ;
+        $repo = new Repo("doil", "https://test/doil.git", false);
+        $repo_manager
+            ->expects($this->once())
+            ->method("repoNameExists")
+            ->with($repo)
+            ->willReturn(true)
+        ;
+
+        $execute_result = $tester->execute(["--no-interaction" => true, "--name" => "doil", "--url" => "https://test/doil.git"]);
+        $output = $tester->getDisplay(true);
+
+        $result = "Error:\n\tRepository with name 'doil' already exists!\n\tUse doil repo:list to see current installed repos.\n";
         $this->assertEquals($result, $output);
         $this->assertEquals(1, $execute_result);
     }
@@ -161,7 +192,13 @@ class AddCommandTest extends TestCase
         $repo = new Repo("doil", "https://test/doil.git", false);
         $repo_manager
             ->expects($this->once())
-            ->method("repoExists")
+            ->method("repoUrlExists")
+            ->with($repo)
+            ->willReturn(false)
+        ;
+        $repo_manager
+            ->expects($this->once())
+            ->method("repoNameExists")
             ->with($repo)
             ->willReturn(false)
         ;

--- a/app/tests/Commands/Repo/DeleteCommandTest.php
+++ b/app/tests/Commands/Repo/DeleteCommandTest.php
@@ -69,7 +69,7 @@ class DeleteCommandTest extends TestCase
         $repo = new Repo("doil");
         $repo_manager
             ->expects($this->once())
-            ->method("repoExists")
+            ->method("repoNameExists")
             ->with($repo)
             ->willReturn(false)
         ;
@@ -98,7 +98,7 @@ class DeleteCommandTest extends TestCase
         $repo = new Repo("doil");
         $repo_manager
             ->expects($this->once())
-            ->method("repoExists")
+            ->method("repoNameExists")
             ->with($repo)
             ->willReturn(true)
         ;

--- a/app/tests/Commands/Repo/UpdateCommandTest.php
+++ b/app/tests/Commands/Repo/UpdateCommandTest.php
@@ -67,7 +67,7 @@ class UpdateCommandTest extends TestCase
         $repo = new Repo("doil");
         $repo_manager
             ->expects($this->once())
-            ->method("repoExists")
+            ->method("repoNameExists")
             ->with($repo)
             ->willReturn(false)
         ;
@@ -96,7 +96,7 @@ class UpdateCommandTest extends TestCase
         $repo = new Repo("doil");
         $repo_manager
             ->expects($this->once())
-            ->method("repoExists")
+            ->method("repoNameExists")
             ->with($repo)
             ->willReturn(true)
         ;


### PR DESCRIPTION
https://github.com/conceptsandtraining/doil/issues/294