### PR TITLE
frh create:306 prohibit uppercase letters for name, depending on docker doesn't allow them for image names

### DIFF
--- a/app/src/Commands/Instances/CreateCommand.php
+++ b/app/src/Commands/Instances/CreateCommand.php
@@ -564,8 +564,8 @@ class CreateCommand extends Command
             if (is_null($name) || "" == $name) {
                 throw new RuntimeException("Name of the instance cannot be empty!");
             }
-            if (! preg_match("/^[a-zA-Z0-9_]*$/", $name)) {
-                throw new RuntimeException("Invalid characters! Only letters, numbers and underscores are allowed!");
+            if (! preg_match("/^[a-z0-9_]*$/", $name)) {
+                throw new RuntimeException("Invalid characters! Only lowercase letters, numbers and underscores are allowed!");
             }
 
             return $name;

--- a/app/src/Commands/Pack/ImportCommand.php
+++ b/app/src/Commands/Pack/ImportCommand.php
@@ -278,8 +278,8 @@ class ImportCommand extends Command
             if ("" == $name) {
                 throw new RuntimeException("Name of the instance cannot be empty!");
             }
-            if (! preg_match("/^[a-zA-Z0-9_]*$/", $name)) {
-                throw new RuntimeException("Invalid characters! Only letters and numbers are allowed!");
+            if (! preg_match("/^[a-z0-9_]*$/", $name)) {
+                throw new RuntimeException("Invalid characters! Only lowercase letters, numbers and underscores are allowed!");
             }
 
             return $name;

--- a/app/src/Commands/Repo/AddCommand.php
+++ b/app/src/Commands/Repo/AddCommand.php
@@ -126,8 +126,8 @@ class AddCommand extends Command
             if ("" == $name) {
                 throw new RuntimeException("Name of the repo cannot be empty!");
             }
-            if (! preg_match("/^[a-zA-Z0-9_]*$/", $name)) {
-                throw new RuntimeException("Invalid characters! Only letters, numbers and underscores are allowed!");
+            if (! preg_match("/^[a-z0-9_]*$/", $name)) {
+                throw new RuntimeException("Invalid characters! Only lowercase letters, numbers and underscores are allowed!");
             }
 
             return $name;

--- a/app/tests/Commands/Instances/CreateCommandTest.php
+++ b/app/tests/Commands/Instances/CreateCommandTest.php
@@ -71,8 +71,8 @@ class CreateCommandTest extends TestCase
         $command->setApplication($app);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Invalid characters! Only letters, numbers and underscores are allowed!");
-        $tester->execute(["--no-interaction" => true, "--name" => "12$32"]);
+        $this->expectExceptionMessage("Invalid characters! Only lowercase letters, numbers and underscores are allowed!");
+        $tester->execute(["--no-interaction" => true, "--name" => "FooBar"]);
     }
 
     public function test_execute_with_no_repo_param() : void

--- a/app/tests/Commands/Pack/ExportCommandTest.php
+++ b/app/tests/Commands/Pack/ExportCommandTest.php
@@ -54,7 +54,7 @@ class ExportCommandTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Invalid characters! Only letters and numbers are allowed!");
-        $tester->execute(["instance" => "32$2323"]);
+        $tester->execute(["instance" => "Foo§Bar"]);
     }
 
     public function test_execute_with_no_docker_compose_file() : void

--- a/app/tests/Commands/Pack/ImportCommandTest.php
+++ b/app/tests/Commands/Pack/ImportCommandTest.php
@@ -89,14 +89,15 @@ class ImportCommandTest extends TestCase
         $docker = $this->createMock(Docker::class);
         $posix = $this->createMock(Posix::class);
         $filesystem = $this->createMock(Filesystem::class);
+        $repo_manager = $this->createMock(RepoManager::class);
         $writer = new CommandWriter();
 
-        $command = new ExportCommand($docker, $posix, $filesystem, $writer);
+        $command = new ImportCommand($docker, $posix, $filesystem, $repo_manager, $writer);
         $tester = new CommandTester($command);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Name of the instance cannot be empty!");
-        $tester->execute(["instance" => ""]);
+        $tester->execute(["instance" => "", "package" => "foo.zip"]);
     }
 
     public function test_execute_with_wrong_chars_in_instance_param() : void
@@ -104,13 +105,14 @@ class ImportCommandTest extends TestCase
         $docker = $this->createMock(Docker::class);
         $posix = $this->createMock(Posix::class);
         $filesystem = $this->createMock(Filesystem::class);
+        $repo_manager = $this->createMock(RepoManager::class);
         $writer = new CommandWriter();
 
-        $command = new ExportCommand($docker, $posix, $filesystem, $writer);
+        $command = new ImportCommand($docker, $posix, $filesystem, $repo_manager, $writer);
         $tester = new CommandTester($command);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Invalid characters! Only letters and numbers are allowed!");
-        $tester->execute(["instance" => "32$2323"]);
+        $this->expectExceptionMessage("Invalid characters! Only lowercase letters, numbers and underscores are allowed!");
+        $tester->execute(["instance" => "FooBar", "package" => "foo.zip"]);
     }
 }

--- a/app/tests/Commands/Repo/AddCommandTest.php
+++ b/app/tests/Commands/Repo/AddCommandTest.php
@@ -60,9 +60,9 @@ class AddCommandTest extends TestCase
         ;
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Invalid characters! Only letters, numbers and underscores are allowed!");
+        $this->expectExceptionMessage("Invalid characters! Only lowercase letters, numbers and underscores are allowed!");
 
-        $execute_result = $tester->execute(["--no-interaction" => true, "--name" => "33%sj", "--url" => "https://test/doil"]);
+        $execute_result = $tester->execute(["--no-interaction" => true, "--name" => "FooBar", "--url" => "https://test/doil"]);
         $this->assertEquals(1, $execute_result);
     }
 

--- a/app/tests/Commands/Repo/DeleteCommandTest.php
+++ b/app/tests/Commands/Repo/DeleteCommandTest.php
@@ -49,7 +49,7 @@ class DeleteCommandTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Invalid characters! Only letters, numbers and underscores are allowed!");
-        $execute_result = $tester->execute(["name" => "3209§09klj"]);
+        $execute_result = $tester->execute(["name" => "Foo§Bar"]);
         $this->assertEquals(1, $execute_result);
     }
 

--- a/app/tests/Commands/Repo/UpdateCommandTest.php
+++ b/app/tests/Commands/Repo/UpdateCommandTest.php
@@ -48,7 +48,7 @@ class UpdateCommandTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage("Invalid characters! Only letters, numbers and underscores are allowed!");
-        $tester->execute(["name" => "324$34"]);
+        $tester->execute(["name" => "Foo§Bar"]);
     }
 
     public function test_execute_with_non_existing_repo() : void


### PR DESCRIPTION
https://github.com/conceptsandtraining/doil/issues/306