### PR TITLE
master Delete: 403 delete command now requires root privileges

### DIFF
--- a/app/src/App.php
+++ b/app/src/App.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Command\Command;
 
 class App extends Application
 {
-    const NAME = "Doil Version 20231102 - build 2023-11-02";
+    const NAME = "Doil Version 20231114 - build 2023-11-14";
 
     public function __construct(Command ...$commands)
     {

--- a/app/src/Commands/Instances/DeleteCommand.php
+++ b/app/src/Commands/Instances/DeleteCommand.php
@@ -24,7 +24,7 @@ class DeleteCommand extends Command
 
     protected static $defaultName = "instances:delete";
     protected static $defaultDescription =
-        "This command deletes one or all instances. It will remove everything belonging " .
+        "<fg=red>!NEEDS SUDO PRIVILEGES!</> This command deletes one or all instances. It will remove everything belonging " .
         "to the given instance including all its files, configuration and misc data."
     ;
 
@@ -55,6 +55,14 @@ class DeleteCommand extends Command
 
     public function execute(InputInterface $input, OutputInterface $output) : int
     {
+        if (! $this->posix->isSudo()) {
+            $this->writer->error(
+                $output,
+                "Please execute this script as sudo user!"
+            );
+            return Command::FAILURE;
+        }
+
         $instance = $input->getArgument("instance");
         $all = $input->getOption("all");
 

--- a/app/src/Lib/Docker/DockerShell.php
+++ b/app/src/Lib/Docker/DockerShell.php
@@ -60,6 +60,14 @@ class DockerShell implements Docker
             "rm -f /run/apache2/apache2.pid &>/dev/null"
         );
 
+        $this->executeCommand(
+            $path,
+            basename($path),
+            "/bin/bash",
+            "-c",
+            "killall salt-minion &>/dev/null && /etc/init.d/salt-minion start &>/dev/null"
+        );
+
        $this->cleanupMasterKey($path);
     }
 

--- a/app/tests/Commands/Instances/DeleteCommandTest.php
+++ b/app/tests/Commands/Instances/DeleteCommandTest.php
@@ -13,6 +13,31 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 class DeleteCommandTest extends TestCase
 {
+    public function test_execute_with_non_root_user() : void
+    {
+        $docker = $this->createMock(Docker::class);
+        $posix = $this->createMock(Posix::class);
+        $filesystem = $this->createMock(Filesystem::class);
+        $writer = new CommandWriter();
+        $instance = "master";
+
+        $command = new DeleteCommand($docker, $posix, $filesystem, $writer);
+        $tester = new CommandTester($command);
+
+        $posix
+            ->expects($this->once())
+            ->method("isSudo")
+            ->willReturn(false)
+        ;
+
+        $execute_result = $tester->execute(["instance" => $instance, "--global" => false]);
+        $output = $tester->getDisplay(true);
+
+        $result = "Error:\n\tPlease execute this script as sudo user!\n\t\n";
+        $this->assertEquals($result, $output);
+        $this->assertEquals(1, $execute_result);
+    }
+
     public function test_execute_with_non_existing_local_dir() : void
     {
         $docker = $this->createMock(Docker::class);
@@ -24,6 +49,11 @@ class DeleteCommandTest extends TestCase
         $command = new DeleteCommand($docker, $posix, $filesystem, $writer);
         $tester = new CommandTester($command);
 
+        $posix
+            ->expects($this->once())
+            ->method("isSudo")
+            ->willReturn(true)
+        ;
         $posix
             ->expects($this->once())
             ->method("getUserId")
@@ -62,6 +92,11 @@ class DeleteCommandTest extends TestCase
         $command = new DeleteCommand($docker, $posix, $filesystem, $writer);
         $tester = new CommandTester($command);
 
+        $posix
+            ->expects($this->once())
+            ->method("isSudo")
+            ->willReturn(true)
+        ;
         $filesystem
             ->expects($this->once())
             ->method("exists")
@@ -90,6 +125,11 @@ class DeleteCommandTest extends TestCase
         $app = new Application("doil");
         $command->setApplication($app);
 
+        $posix
+            ->expects($this->once())
+            ->method("isSudo")
+            ->willReturn(true)
+        ;
         $filesystem
             ->expects($this->once())
             ->method("exists")
@@ -126,6 +166,11 @@ class DeleteCommandTest extends TestCase
             ->willReturn(true)
         ;
 
+        $posix
+            ->expects($this->once())
+            ->method("isSudo")
+            ->willReturn(true)
+        ;
         $posix
             ->expects($this->once())
             ->method("getUserId")

--- a/setup/doil.sh
+++ b/setup/doil.sh
@@ -74,6 +74,7 @@ docker run --rm "${TERMINAL}" \
   -v /etc:/etc \
   -v /var/log:/var/log \
   -e  PHP_INI_SCAN_DIR=/srv/php/mods-available \
+  -e  SUDO_UID="$SUDO_UID" \
   $GLOBAL_INSTANCES_PATH \
   -w $(pwd) \
   $MAP_USER \

--- a/setup/updates/update-20231114.sh
+++ b/setup/updates/update-20231114.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+source ${SCRIPT_DIR}/updates/update.sh
+
+doil_update_20231114() {
+  update
+  return $?
+}


### PR DESCRIPTION
also fix multiple salt-minion processes at startup of a doil instance