### PR TITLE
master compose/buildx: adjust docker calls to the new docker api

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ will move all global instances to the set path.
 **doil** tries to use as little 3rd party software on the host system as possible,
 however **doil** needs [Docker](https://www.docker.com/) in order to work:
 
-* docker version >= 19.03
-* docker-compose version >= 1.25.0 (ensure that root has access too)
+* docker (follow [this](https://docs.docker.com/engine/install/) instructions depending on your os to install docker), if you have installed docker by your package manager ensure that **docker-buildx-plugin** and **docker-compose-plugin** are available and installed and also executable by your user.
 * git
 * .ssh folder in your home directory. **doil** will mount it into the container. **doil** needs this to have access to any private git repositories that may be used. 
 

--- a/app/src/App.php
+++ b/app/src/App.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Command\Command;
 
 class App extends Application
 {
-    const NAME = "Doil Version 20240214 - build 2024-02-14";
+    const NAME = "Doil Version 20240307 - build 2024-03-07";
 
     public function __construct(Command ...$commands)
     {

--- a/app/src/Lib/Docker/DockerShell.php
+++ b/app/src/Lib/Docker/DockerShell.php
@@ -37,7 +37,8 @@ class DockerShell implements Docker
         }
 
         $cmd = [
-            "docker-compose",
+            "docker",
+            "compose",
             "-f",
             $path . "/docker-compose.yml",
             "up",
@@ -74,7 +75,8 @@ class DockerShell implements Docker
     public function stopContainerByDockerCompose(string $path) : void
     {
         $cmd = [
-            "docker-compose",
+            "docker",
+            "compose",
             "-f",
             $path . "/docker-compose.yml",
             "stop"
@@ -115,7 +117,8 @@ class DockerShell implements Docker
     public function loginIntoContainer(string $path, string $name) : void
     {
         $cmd = [
-            "docker-compose",
+            "docker",
+            "compose",
             "-f",
             $path . "/docker-compose.yml",
             "exec",
@@ -133,7 +136,8 @@ class DockerShell implements Docker
     public function isInstanceUp(string $path) : bool
     {
         $cmd = [
-           "docker-compose",
+           "docker",
+           "compose",
            "-f",
            $path . "/docker-compose.yml",
            "top"
@@ -146,7 +150,8 @@ class DockerShell implements Docker
     public function executeCommand(string $path, string $name, ...$command) : void
     {
         $cmd = [
-            "docker-compose",
+            "docker",
+            "compose",
             "-f",
             $path . "/docker-compose.yml",
             "exec",
@@ -164,7 +169,8 @@ class DockerShell implements Docker
     public function executeNoTTYCommand(string $path, string $name, ...$command) : void
     {
         $cmd = [
-            "docker-compose",
+            "docker",
+            "compose",
             "-f",
             $path . "/docker-compose.yml",
             "exec",
@@ -389,6 +395,7 @@ class DockerShell implements Docker
     {
         $cmd = [
             "docker",
+            "buildx",
             "build",
             "-t",
             "doil/" . $name . ":stable",
@@ -572,7 +579,8 @@ class DockerShell implements Docker
     protected function startContainerByDockerComposeWithForceRecreate(string $path) : void
     {
         $cmd = [
-            "docker-compose",
+            "docker",
+            "compose",
             "-f",
             $path . "/docker-compose.yml",
             "up",

--- a/setup/system.sh
+++ b/setup/system.sh
@@ -344,13 +344,13 @@ function doil_system_delete_potential_composer_lock() {
 }
 
 function doil_system_build_php_image() {
-  (docker build -q -t doil_php:stable /usr/local/lib/doil/server/php) 2>&1 > /var/log/doil/stream.log
+  (docker buildx build -q -t doil_php:stable /usr/local/lib/doil/server/php) 2>&1 > /var/log/doil/stream.log
   docker run --rm -ti -v /home:/home -v /usr/local/lib/doil:/usr/local/lib/doil -e PHP_INI_SCAN_DIR=/srv/php/mods-available -w /usr/local/lib/doil/app --user $(id -u):$(id -g) doil_php:stable /usr/local/bin/composer -q -n install
 }
 
 function doil_system_install_saltserver() {
   cd /usr/local/lib/doil/server/salt
-  BUILD=$(docker-compose up -d 2>&1 > /var/log/doil/stream.log) 2>&1 > /var/log/doil/stream.log
+  BUILD=$(docker compose up -d 2>&1 > /var/log/doil/stream.log) 2>&1 > /var/log/doil/stream.log
   docker commit doil_saltmain doil_saltmain:stable 2>&1 > /var/log/doil/stream.log
 }
 
@@ -358,7 +358,7 @@ function doil_system_install_proxyserver() {
   cd /usr/local/lib/doil/server/proxy
   NAME=$(cat /etc/doil/doil.conf | grep "host" | cut -d '=' -f 2-)
   sed -i "s/%TPL_SERVER_NAME%/${NAME}/g" "/usr/local/lib/doil/server/proxy/conf/nginx/local.conf"
-  BUILD=$(docker-compose up -d 2>&1 > /var/log/doil/stream.log) 2>&1 > /var/log/doil/stream.log
+  BUILD=$(docker compose up -d 2>&1 > /var/log/doil/stream.log) 2>&1 > /var/log/doil/stream.log
   sleep 10
   docker exec -i doil_saltmain bash -c "salt 'doil.proxy' state.highstate saltenv=proxyservices" 2>&1 > /var/log/doil/stream.log
   docker commit doil_proxy doil_proxy:stable 2>&1 > /var/log/doil/stream.log
@@ -366,7 +366,7 @@ function doil_system_install_proxyserver() {
 
 function doil_system_install_mailserver() {
   cd /usr/local/lib/doil/server/mail
-  BUILD=$(docker-compose up -d 2>&1 > /var/log/doil/stream.log) 2>&1 > /var/log/doil/stream.log
+  BUILD=$(docker compose up -d 2>&1 > /var/log/doil/stream.log) 2>&1 > /var/log/doil/stream.log
   sleep 10
   docker exec -i doil_saltmain bash -c "salt 'doil.mail' state.highstate saltenv=mailservices" 2>&1 > /var/log/doil/stream.log
   PASSWORD=$(doil_get_conf mail_password)

--- a/setup/templates/php/Dockerfile
+++ b/setup/templates/php/Dockerfile
@@ -1,6 +1,12 @@
 FROM debian:11
 
-RUN apt-get update && apt-get install -y vim curl zip unzip git php7.4-cli php7.4-zip php7.4-dom php7.4-mbstring php7.4-json docker.io docker-compose
+RUN apt-get update && apt-get install -y vim ca-certificates curl zip unzip git php7.4-cli php7.4-zip php7.4-dom php7.4-mbstring php7.4-json
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+RUN chmod a+r /etc/apt/keyrings/docker.asc
+
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 RUN EXPECTED_CHECKSUM="$(php -r 'copy("https://composer.github.io/installer.sig", "php://stdout");')"
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"

--- a/setup/updates/update-20240307.sh
+++ b/setup/updates/update-20240307.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+source ${SCRIPT_DIR}/updates/update.sh
+
+doil_update_20240307() {
+  update
+  return $?
+}


### PR DESCRIPTION
**!!! Achtung !!!**
Dieser PR darf erst gemerged werden wenn Ubuntu die Pakete docker-compose-plugin und docker-buildx-plugin in ihren offiziellen Repos bereit stellt.
Oder @klees  gibt das Ok, dass wir docker über diesen Weg installieren https://docs.docker.com/engine/install/ubuntu/.