### PR TITLE
master states:442 distribute update token as environment var

### DIFF
--- a/app/src/App.php
+++ b/app/src/App.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Command\Command;
 
 class App extends Application
 {
-    const NAME = "Doil Version 20240604 - build 2024-06-04";
+    const NAME = "Doil Version 20240609 - build 2024-06-09";
 
     public function __construct(Command ...$commands)
     {

--- a/app/src/Commands/Instances/ApplyCommand.php
+++ b/app/src/Commands/Instances/ApplyCommand.php
@@ -33,7 +33,9 @@ class ApplyCommand extends Command
         "reactor",
         "change-roundcube-password",
         "nodejs",
-        "proxy-enable-https"
+        "proxy-enable-https",
+        "ilias-update-hook",
+        "set-update-token"
     ];
 
     protected static $defaultName = "instances:apply";

--- a/app/src/Commands/Instances/CreateCommand.php
+++ b/app/src/Commands/Instances/CreateCommand.php
@@ -299,7 +299,11 @@ class CreateCommand extends Command
             $cron_password = $this->generatePassword(16);
         }
         $host = explode("=", $this->filesystem->getLineInFile("/etc/doil/doil.conf", "host"));
+        $update_token = explode("=", $this->filesystem->getLineInFile("/etc/doil/doil.conf", "update_token"));
+
         $this->docker->setGrain($instance_salt_name, "mysql_password", "$mysql_password");
+        sleep(1);
+        $this->docker->setGrain($instance_salt_name, "update_token", "${update_token[1]}");
         sleep(1);
         $this->docker->setGrain($instance_salt_name, "cron_password", "$cron_password");
         sleep(1);
@@ -365,6 +369,16 @@ class CreateCommand extends Command
             $this->docker->applyState($instance_salt_name, "enable-xdebug");
             $this->writer->endBlock();
         }
+
+        // apply set-update-token state
+        $this->writer->beginBlock($output, "Apply set-update-token state");
+        $this->docker->applyState($instance_salt_name, "set-update-token");
+        $this->writer->endBlock();
+
+        // apply ilias-update-hook state
+        $this->writer->beginBlock($output, "Apply ilias-update-hook state");
+        $this->docker->applyState($instance_salt_name, "ilias-update-hook");
+        $this->writer->endBlock();
 
         // apply access state
         $this->writer->beginBlock($output, "Apply access state");

--- a/app/src/Commands/Instances/SetUpdateTokenCommand.php
+++ b/app/src/Commands/Instances/SetUpdateTokenCommand.php
@@ -1,0 +1,155 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2022 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+namespace CaT\Doil\Commands\Instances;
+
+use CaT\Doil\Lib\Posix\Posix;
+use CaT\Doil\Lib\Docker\Docker;
+use CaT\Doil\Lib\ConsoleOutput\Writer;
+use CaT\Doil\Lib\FileSystem\Filesystem;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+
+class SetUpdateTokenCommand extends Command
+{
+    protected static $defaultName = "instances:set-update-token";
+    protected static $defaultDescription =
+        "<fg=red>!NEEDS SUDO PRIVILEGES!</> This command sets a update token for all instances"
+    ;
+
+    protected Docker $docker;
+    protected Posix $posix;
+    protected Filesystem $filesystem;
+    protected Writer $writer;
+
+    public function __construct(Docker $docker, Posix $posix, Filesystem $filesystem, Writer $writer)
+    {
+        parent::__construct();
+
+        $this->docker = $docker;
+        $this->posix = $posix;
+        $this->filesystem = $filesystem;
+        $this->writer = $writer;
+    }
+
+    public function configure() : void
+    {
+        $this
+            ->setAliases(["sut"])
+            ->addArgument("instance", InputArgument::OPTIONAL, "Name of the instance to set update token for")
+            ->addOption("token", "t", InputOption::VALUE_REQUIRED, "Update token as string")
+            ->addOption("global", "g", InputOption::VALUE_NONE, "Determines if an instance is global or not")
+        ;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        if (! $this->posix->isSudo()) {
+            $this->writer->error(
+                $output,
+                "Please execute this script as sudo user!"
+            );
+            return Command::FAILURE;
+        }
+
+        $token = $input->getOption("token");
+
+        $home_dir = $this->posix->getHomeDirectory($this->posix->getUserId());
+
+        $path = "/usr/local/share/doil/instances";
+        $suffix = ".global";
+        if (! $input->getOption("global")) {
+            $path = "$home_dir/.doil/instances";
+            $suffix = ".local";
+        }
+
+        $instances = $this->filesystem->getFilesInPath($path);
+        if (count($instances) == 0) {
+            $this->writer->error(
+                $output,
+                "No instances found!",
+                "Use <fg=gray>doil instances:ls --help</> for more information."
+            );
+            return Command::FAILURE;
+        }
+
+        $question = new ConfirmationQuestion(
+            "This will also update 'update_token' in your doil config. Want to continue? [yN]: ",
+            false
+        );
+
+        $helper = $this->getHelper("question");
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln("Abort by user!");
+            return Command::FAILURE;
+        }
+
+        $this->filesystem->replaceLineInFile("/etc/doil/doil.conf", "/update_token=.*/", "update_token=" . $token);
+
+        foreach ($instances as $i) {
+            $started = $this->startInstance($output, $path, $i);
+            sleep(3);
+            $this->applyUpdateToken($output, $i . $suffix, $token);
+            if ($started) {
+                $this->stopInstance($output, $path, $i);
+            }
+        }
+        return Command::SUCCESS;
+    }
+
+    protected function startInstance(OutputInterface $output, string $path, string $instance) : bool
+    {
+        if (! $this->hasDockerComposeFile($path . "/" . $instance, $output)) {
+            throw new InvalidArgumentException("Can't find a suitable docker-compose.yml file in $path/$instance");
+        }
+
+        if (! $this->docker->isInstanceUp($path . "/" . $instance)) {
+            $this->writer->beginBlock($output, "Start instance $instance");
+            $this->docker->startContainerByDockerCompose($path . "/" . $instance);
+            $this->writer->endBlock();
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function stopInstance(OutputInterface $output, string $path, string $instance) : string
+    {
+        if ($this->docker->isInstanceUp($path . "/" . $instance)) {
+            $this->writer->beginBlock($output, "Stop instance $instance");
+            $this->docker->stopContainerByDockerCompose($path . "/" . $instance);
+            $this->writer->endBlock();
+        }
+
+        return $instance;
+    }
+
+    protected function hasDockerComposeFile(string $path, OutputInterface $output) : bool
+    {
+        if ($this->filesystem->exists($path . "/docker-compose.yml")) {
+            return true;
+        }
+
+        $output->writeln("<fg=red>Error:</>");
+        $output->writeln("\tCan't find a suitable docker-compose file in this directory '$path'.");
+        $output->writeln("\tIs this the right directory?");
+        $output->writeln("\tSupported filenames: docker-compose.yml");
+
+        return false;
+    }
+
+    protected function applyUpdateToken(OutputInterface $output, string $salt_key, string $token)
+    {
+        $this->writer->beginBlock($output, "Apply update token to $salt_key");
+        $this->docker->setGrain($salt_key, "update_token", $token);
+        $this->docker->refreshGrains($salt_key);
+        $this->docker->applyState($salt_key, "set-update-token");
+        $this->writer->endBlock();
+    }
+}

--- a/app/src/Commands/Pack/PackCreateCommand.php
+++ b/app/src/Commands/Pack/PackCreateCommand.php
@@ -300,7 +300,11 @@ class PackCreateCommand extends Command
             $cron_password = $this->generatePassword(16);
         }
         $host = explode("=", $this->filesystem->getLineInFile("/etc/doil/doil.conf", "host"));
+        $update_token = explode("=", $this->filesystem->getLineInFile("/etc/doil/doil.conf", "update_token"));
+
         $this->docker->setGrain($instance_salt_name, "mysql_password", $mysql_password);
+        sleep(1);
+        $this->docker->setGrain($instance_salt_name, "update_token", "${update_token[1]}");
         sleep(1);
         $this->docker->setGrain($instance_salt_name, "cron_password", $cron_password);
         sleep(1);
@@ -352,6 +356,16 @@ class PackCreateCommand extends Command
             $this->docker->applyState($instance_salt_name, "nodejs");
             $this->writer->endBlock();
         }
+
+        // apply set-update-token state
+        $this->writer->beginBlock($output, "Apply set-update-token state");
+        $this->docker->applyState($instance_salt_name, "set-update-token");
+        $this->writer->endBlock();
+
+        // apply ilias-update-hook state
+        $this->writer->beginBlock($output, "Apply ilias-update-hook state");
+        $this->docker->applyState($instance_salt_name, "ilias-update-hook");
+        $this->writer->endBlock();
 
         // apply access state
         $this->writer->beginBlock($output, "Apply access state");

--- a/app/src/cli.php
+++ b/app/src/cli.php
@@ -43,6 +43,7 @@ function buildContainerForApp() : Container
             $c["command.instances.login"],
             $c["command.instances.path"],
             $c["command.instances.restart"],
+            $c["command.instances.set.update.token"],
             $c["command.instances.status"],
             $c["command.instances.up"],
             $c["command.mail.change.password"],
@@ -219,6 +220,15 @@ function buildContainerForApp() : Container
 
     $c["command.instances.restart"] = function($c) {
         return new Instances\RestartCommand(
+            $c["docker.shell"],
+            $c["posix.shell"],
+            $c["filesystem.shell"],
+            $c["command.writer"]
+        );
+    };
+
+    $c["command.instances.set.update.token"] = function($c) {
+        return new Instances\SetUpdateTokenCommand(
             $c["docker.shell"],
             $c["posix.shell"],
             $c["filesystem.shell"],

--- a/app/tests/Commands/Instances/CreateCommandTest.php
+++ b/app/tests/Commands/Instances/CreateCommandTest.php
@@ -325,10 +325,10 @@ class CreateCommandTest extends TestCase
             ->willReturn(false, true, true)
         ;
         $filesystem
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method("getLineInFile")
-            ->with("/etc/doil/doil.conf", "host")
-            ->willReturnOnConsecutiveCalls("foo=doil", "7.8")
+            ->withConsecutive(["/etc/doil/doil.conf", "host"], ["/etc/doil/doil.conf", "update_token"])
+            ->willReturnOnConsecutiveCalls("foo=doil", "update_token=foobar")
         ;
         $filesystem
             ->expects($this->once())

--- a/setup/conf/doil.conf
+++ b/setup/conf/doil.conf
@@ -2,3 +2,4 @@ group=doil
 host=doil
 mail_password=ilias
 global_instances_path=/srv/instances
+update_token=foobar

--- a/setup/stack/config/master.cnf
+++ b/setup/stack/config/master.cnf
@@ -676,6 +676,8 @@ file_roots:
     - /srv/salt/states/php8.2
   ilias:
     - /srv/salt/states/ilias
+  ilias-update-hook:
+    - srv/salt/states/ilias-update-hook
   compile-skins:
     - /srv/salt/states/compile-skins
   composer:
@@ -706,6 +708,8 @@ file_roots:
     - /srv/salt/states/enable-https
   disable-https:
     - /srv/salt/states/disable-https
+  set-update-token:
+      - /srv/salt/states/set-update-token
 
 
 # The master_roots setting configures a master-only copy of the file_roots dictionary,

--- a/setup/stack/states/ilias-update-hook/description.txt
+++ b/setup/stack/states/ilias-update-hook/description.txt
@@ -1,0 +1,1 @@
+description = Inject an update hook file into docroot

--- a/setup/stack/states/ilias-update-hook/ilias-update-hook/init.sls
+++ b/setup/stack/states/ilias-update-hook/ilias-update-hook/init.sls
@@ -1,0 +1,8 @@
+{% set ilias_version = salt['grains.get']('ilias_version', '8.0') %}
+
+/var/www/html/.update_hook.php:
+  file.managed:
+    - source: salt://ilias-update-hook/update_hook.php.j2
+    - template: jinja
+    - context:
+      ilias_version: {{ ilias_version }}

--- a/setup/stack/states/ilias-update-hook/ilias-update-hook/update_hook.php.j2
+++ b/setup/stack/states/ilias-update-hook/ilias-update-hook/update_hook.php.j2
@@ -1,0 +1,69 @@
+<?php declare(strict_types=1);
+
+/* Copyright (c) 2024 - Daniel Weise <daniel.weise@concepts-and-training.de> - Extended GPL, see LICENSE */
+
+$request_headers = apache_request_headers();
+if (is_null($request_headers) || !array_key_exists("Authorization", $request_headers)) {
+    http_response_code(401);
+    throw new Exception("Missing Authorization header");
+}
+$request_token = $request_headers["Authorization"];
+
+$environment_token = getenv("UPDATE_TOKEN");
+if (is_null($environment_token)) {
+    http_response_code(401);
+    throw new Exception("Missing Environment Token");
+}
+
+if ($environment_token !== $request_token) {
+    http_response_code(401);
+    throw new Exception("Invalid Token");
+}
+
+// Pull current checked out branch from origin
+$pull_output = [];
+$result_code = 0;
+$branch = exec("git branch --show-current");
+exec("git pull origin " . $branch . " 2>&1", $pull_output, $result_code);
+if ($result_code !== 0) {
+    http_response_code(500);
+    throw new Exception("Failed to run update hook");
+}
+
+// Run composer install
+$composer_output = [];
+$result_code = 0;
+exec("COMPOSER_HOME=/usr/local/bin/composer composer install 2>&1", $composer_output, $result_code);
+if ($result_code !== 0) {
+    http_response_code(500);
+    throw new Exception("Failed to run update hook");
+}
+
+// Run ilias update
+$update_output = [];
+$result_code = 0;
+{% if ilias_version | int < 10 %}
+exec("php " . __DIR__ . "/setup/setup.php update -y 2>&1", $update_output, $result_code);
+{% else %}
+exec("php " . __DIR__ . "/cli/setup.php update -y 2>&1", $update_output, $result_code);
+{% endif %}
+if ($result_code !== 0) {
+    http_response_code(500);
+    throw new Exception("Failed to run update hook");
+}
+
+$output = "";
+foreach ($pull_output as $line) {
+    $output .= $line . "</br>";
+}
+
+foreach ($composer_output as $line) {
+    $output .= $line . "</br>";
+}
+
+foreach ($update_output as $line) {
+    $output .= $line . "</br>";
+}
+
+echo $output;
+

--- a/setup/stack/states/ilias-update-hook/top.sls
+++ b/setup/stack/states/ilias-update-hook/top.sls
@@ -1,0 +1,3 @@
+ilias-update-hook:
+  '*':
+    - ilias-update-hook

--- a/setup/stack/states/proxyservices/proxyservices/service-config.tpl
+++ b/setup/stack/states/proxyservices/proxyservices/service-config.tpl
@@ -8,3 +8,14 @@ location /%DOMAIN%/ {
 
     rewrite          ^/%DOMAIN%/(.*) /%DOMAIN%/$1 break;
 }
+
+location /%DOMAIN%/update/ {
+proxy_pass       http://%IP%/;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP  $remote_addr;
+proxy_set_header X-Forwarded-For $remote_addr;
+proxy_pass_request_headers on;
+proxy_set_header X-Forwarded-Proto https;
+
+rewrite          ^/%DOMAIN%/(.*) /%DOMAIN%/.update_hook.php break;
+}

--- a/setup/stack/states/set-update-token/description.txt
+++ b/setup/stack/states/set-update-token/description.txt
@@ -1,0 +1,1 @@
+description = Set an update token for all instances

--- a/setup/stack/states/set-update-token/set-update-token/init.sls
+++ b/setup/stack/states/set-update-token/set-update-token/init.sls
@@ -1,0 +1,7 @@
+{% set update_token = salt['grains.get']('update_token', '') %}
+
+/etc/apache2/envvars:
+  file.replace:
+    - pattern: '^export UPDATE_TOKEN=.*$'
+    - repl: 'export UPDATE_TOKEN={{ update_token }}'
+    - append_if_not_found: True

--- a/setup/stack/states/set-update-token/top.sls
+++ b/setup/stack/states/set-update-token/top.sls
@@ -1,0 +1,3 @@
+set-update-token:
+  '*':
+    - set-update-token

--- a/setup/templates/minion/docker-compose.yml
+++ b/setup/templates/minion/docker-compose.yml
@@ -45,6 +45,9 @@ services:
         source: ~/.ssh/
         target: /root/.ssh
       - type: bind
+        source: ~/.ssh/
+        target: /var/www/.ssh
+      - type: bind
         source: ./conf/salt-minion.conf
         target: /etc/supervisor/conf.d/salt-minion.conf
     environment:

--- a/setup/updates/update-20240610.sh
+++ b/setup/updates/update-20240610.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+doil_update_20240610() {
+  cp -r ${SCRIPT_DIR}/../app/src/* /usr/local/lib/doil/app/src/
+  cp -r ${SCRIPT_DIR}/../setup/stack/states/* /usr/local/share/doil/stack/states/
+  cp -r ${SCRIPT_DIR}/../setup/stack/config/* /usr/local/share/doil/stack/config/
+  cp -r ${SCRIPT_DIR}/../setup/templates/minion/* /usr/local/share/doil/templates/minion/
+  doil salt:restart
+  doil proxy:restart
+  sleep 10
+  docker exec -it doil_saltmain /bin/bash -c "salt \"doil.proxy\" state.highstate saltenv=proxyservices" &> /dev/null
+  docker commit doil_proxy doil_proxy:stable
+
+  if [ $(docker ps -a --filter "name=_local" --filter "name=_global" --format "{{.Names}}" | wc -l) -gt 0 ]
+  doil_status_send_message "Applying patch on existing instances"
+  then
+    for INSTANCE in $(docker ps -a --filter "name=_local" --filter "name=_global" --format "{{.Names}}")
+    do
+        STARTED=0
+        NAME=${INSTANCE%_*}
+        SUFFIX=${INSTANCE##*_}
+
+        if [ -L /usr/local/share/doil/instances/"${NAME}" ] || [ -L /home/"${SUDO_USER}"/.doil/instances/"${NAME}" ]
+        then
+          if [ "${SUFFIX}" == "global" ]
+          then
+            INSTANCE_PATH=$(/usr/local/bin/doil path "${NAME}" -g -p)
+            GLOBAL="-g"
+          else
+            INSTANCE_PATH=$(su -c "/usr/local/bin/doil path ${NAME} -p" "${SUDO_USER}")
+            GLOBAL=""
+          fi
+
+          if [[ ! $(docker ps --filter "name=_local" --filter "name=_global" --format "{{.Names}}") =~ ${INSTANCE} ]]
+          then
+            doil up ${NAME} ${GLOBAL}
+            STARTED=1
+          fi
+
+          DOCKER_COMPOSE_PATH="${INSTANCE_PATH}/docker-compose.yml"
+
+          if ! grep -q "target: /var/www/.ssh" "${DOCKER_COMPOSE_PATH}"
+          then
+            sed -i 's/volumes:/&\n      - type: bind\n        source: ~\/.ssh\/\n        target: \/var\/www\/.ssh/' "${DOCKER_COMPOSE_PATH}"
+          fi
+          sleep 5
+          docker exec -it doil_saltmain /bin/bash -c "salt \"${NAME}.${SUFFIX}\" state.highstate saltenv=ilias-update-hook" &> /dev/null
+          if [ ${STARTED} == 1 ]
+          then
+            doil down ${NAME} ${GLOBAL}
+          else
+            doil restart ${NAME} ${GLOBAL}
+          fi
+        fi
+    done
+
+    doil_status_okay
+  fi
+
+  return $?
+}


### PR DESCRIPTION
Dies ist der erste Teil. Hier wird ein in der doil.conf gesetztes Token bei neuen oder importierten Instanzen in die bashrc von root geschrieben, damit es später mit der PHP Funktion getenv() ausgelesen werden kann.

Ausserdem git es ein neues Command 'set-update-token', welches für jede Instanz das Token in der bashrc von root neu setzt und die doil.conf updatet.

Hallo @klees, bitte schau dir das mal an und teil mir mit ob das in die richtige Richtung geht.