### PR TITLE
master saml: add 'sign.logout' => true to authsources.php

### DIFF
--- a/setup/stack/states/enable-saml/saml/authsources.php.j2
+++ b/setup/stack/states/enable-saml/saml/authsources.php.j2
@@ -12,5 +12,6 @@ $config = array(
         'entityID' => '{{ ilias_http_path }}/module.php/saml/sp/metadata.php/default-sp',
         'idp' => $idpentityid,
         'discoURL' => NULL,
+        'sign.logout' => true,
     ),
 );


### PR DESCRIPTION
wird gebraucht, damit bei einem Logout wieder zur ILIAS Startseite gefunden wird